### PR TITLE
Resizeable shape

### DIFF
--- a/src/main/java/com/example/gainns/Dragable.java
+++ b/src/main/java/com/example/gainns/Dragable.java
@@ -4,7 +4,6 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Group;
 import javafx.scene.paint.Paint;
-import javafx.scene.shape.Circle;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
 

--- a/src/main/java/com/example/gainns/Dragable.java
+++ b/src/main/java/com/example/gainns/Dragable.java
@@ -12,7 +12,6 @@ class Dragable extends Group {
 
     Rectangle rectangle = new Rectangle();
     Ellipse ellipse = new Ellipse();
-    Circle circle = new Circle();
     DoubleProperty widthProperty = new SimpleDoubleProperty();
     DoubleProperty heightProperty = new SimpleDoubleProperty();
     
@@ -45,7 +44,7 @@ class Dragable extends Group {
 		    
 		    // set transparency during moving
 		    ellipse.setOnMouseDragged(me -> ellipse.setOpacity(0.7));
-		    ellipse.setOnMouseReleased(me -> ellipse.setOpacity(1));
+		    ellipse.setOnMouseReleased(me ->ellipse.setOpacity(1));
 		}
     }
     

--- a/src/main/java/com/example/gainns/Dragable.java
+++ b/src/main/java/com/example/gainns/Dragable.java
@@ -1,50 +1,52 @@
 package com.example.gainns;
 
-import javafx.scene.Cursor;
-import javafx.scene.paint.Color;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.scene.Group;
+import javafx.scene.paint.Paint;
 import javafx.scene.shape.Circle;
-import javafx.scene.shape.Shape;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
 
-public class Dragable {
+class Dragable extends Group {
 
-	Shape shape;
-	double orgSceneX;
-	double orgSceneY;
-	public Dragable(double x, double y, Color color, String shapeName, double shapeParam0, double shapeParam1) {
-		if (shapeName.equals("Circle")) {
-			this.shape = new Circle(x, y, shapeParam0, color);
-		}else if (shapeName.equals("Rectangle")) {
-			this.shape = new Rectangle(x, y, shapeParam0, shapeParam1);
-			this.shape.setFill(color);
+    Rectangle rectangle = new Rectangle();
+    Ellipse ellipse = new Ellipse();
+    Circle circle = new Circle();
+    DoubleProperty widthProperty = new SimpleDoubleProperty();
+    DoubleProperty heightProperty = new SimpleDoubleProperty();
+    Dragable(double x, double y, Paint fill, String shapeName, double shapeParam0, double shapeParam1){
+    	if (shapeName.equals("Rectangle")) {
+			widthProperty.addListener((v, o, n) -> { rectangle.setWidth(n.doubleValue()); });
+		    heightProperty.addListener((v, o, n) -> { rectangle.setHeight(n.doubleValue()); });
+		    setLayoutX(x);
+		    setLayoutY(y);
+		    widthProperty.set(shapeParam0);
+		    heightProperty.set(shapeParam1);
+		    rectangle.setFill(fill);
+		    getChildren().add(rectangle);
 		}else if (shapeName.equals("Ellipse")) {
-			this.shape = new Ellipse(x, y, shapeParam0, shapeParam1);
-			this.shape.setFill(color);
+			widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
+			heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
+		    setLayoutX(x);
+		    setLayoutY(y);
+		    widthProperty.set(shapeParam0*2);
+		    heightProperty.set(shapeParam1*2);
+		    ellipse.setFill(fill);
+		    getChildren().add(ellipse);
+		}else if (shapeName.equals("Circle")) {
+			widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
+			heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
+		    setLayoutX(x);
+		    setLayoutY(y);
+		    widthProperty.set(shapeParam0*2);
+		    heightProperty.set(shapeParam0*2);
+		    ellipse.setFill(fill);
+		    getChildren().add(ellipse);
 		}
-				  
-		this.shape.setCursor(Cursor.HAND);
-
-		this.shape.setOnMousePressed((t) -> {
-			orgSceneX = t.getSceneX();
-			orgSceneY = t.getSceneY();
-			
-			Shape c = (Shape) (t.getSource());
-			c.setOpacity(0.5);
-			c.toFront();
-	    });
-		
-		this.shape.setOnMouseDragged((t) -> {    				
-			Shape movingShape = (Shape) (t.getSource());
-			movingShape.relocate(t.getSceneX(), t.getSceneY());
-			
-			orgSceneX = t.getSceneX();
-			orgSceneY = t.getSceneY();
-	    });
-		
-		this.shape.setOnMouseReleased((t) -> {
-			Shape c = (Shape) (t.getSource());
-			c.setOpacity(80);
-	    });
-	}
+    }
+    
+    DoubleProperty widthProperty() { return widthProperty; }
+    DoubleProperty heightProperty() { return heightProperty; }
+    @Override public String toString() { return "[" + getLayoutX() + ", " + getLayoutY() + ", " + widthProperty.get() + ", " + heightProperty.get() + "]"; }
 }

--- a/src/main/java/com/example/gainns/Dragable.java
+++ b/src/main/java/com/example/gainns/Dragable.java
@@ -15,6 +15,9 @@ class Dragable extends Group {
     Circle circle = new Circle();
     DoubleProperty widthProperty = new SimpleDoubleProperty();
     DoubleProperty heightProperty = new SimpleDoubleProperty();
+    
+    ShapesMenu shapesMenu;
+    
     Dragable(double x, double y, Paint fill, String shapeName, double shapeParam0, double shapeParam1){
     	if (shapeName.equals("Rectangle")) {
 			widthProperty.addListener((v, o, n) -> { rectangle.setWidth(n.doubleValue()); });
@@ -25,26 +28,27 @@ class Dragable extends Group {
 		    heightProperty.set(shapeParam1);
 		    rectangle.setFill(fill);
 		    getChildren().add(rectangle);
-		}else if (shapeName.equals("Ellipse")) {
+		    
+		    // set transparency during moving
+		    rectangle.setOnMouseDragged(me -> rectangle.setOpacity(0.7));
+		    rectangle.setOnMouseReleased(me -> rectangle.setOpacity(1));
+		}else if (shapeName.equals("Ellipse") || shapeName.equals("Circle")) {
 			widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
 			heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
 		    setLayoutX(x);
 		    setLayoutY(y);
 		    widthProperty.set(shapeParam0*2);
-		    heightProperty.set(shapeParam1*2);
+		    if (shapeName.equals("Circle")) heightProperty.set(shapeParam0*2);
+		    else heightProperty.set(shapeParam1*2);
 		    ellipse.setFill(fill);
 		    getChildren().add(ellipse);
-		}else if (shapeName.equals("Circle")) {
-			widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
-			heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
-		    setLayoutX(x);
-		    setLayoutY(y);
-		    widthProperty.set(shapeParam0*2);
-		    heightProperty.set(shapeParam0*2);
-		    ellipse.setFill(fill);
-		    getChildren().add(ellipse);
+		    
+		    // set transparency during moving
+		    ellipse.setOnMouseDragged(me -> ellipse.setOpacity(0.7));
+		    ellipse.setOnMouseReleased(me -> ellipse.setOpacity(1));
 		}
     }
+    
     
     DoubleProperty widthProperty() { return widthProperty; }
     DoubleProperty heightProperty() { return heightProperty; }

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -2,12 +2,14 @@ package com.example.gainns;
 
 import javafx.animation.TranslateTransition;
 import javafx.application.Application;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Cursor;
+import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.InputEvent;
@@ -15,18 +17,33 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.shape.*;
+import javafx.scene.transform.Scale;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.util.Duration;
-import javafx.util.Pair;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 
 public class Environment extends Application {
-	
+	double resizeBlockWidth = 6, a2 = resizeBlockWidth / 2;
+    double gridSize = -1;
+    double lastX, lastY;
+    double lX, lY, sX, sY, sWidth, sHeight;
+    ScrollPane scrollPane;
+    Group group, overlay = null;
+    
+    
+    // scale change point
+    Rectangle srBnd, srNW, srN, srNE, srE, srSE, srS, srSW, srW;
+    
+    Dragable selectedElement;
+ 
+    AnchorPane root;
+    
 	//temp debug
 	final Label posReporter = new Label();
 	final Label elementInEnvReporter = new Label();
@@ -39,7 +56,10 @@ public class Environment extends Application {
 	// resolution offset
 	private double windowWidth = Screen.getPrimary().getBounds().getWidth()-400;
     private double windowHeight = Screen.getPrimary().getBounds().getHeight()-300;
-	
+    
+    // hard limit: shape will not reach ground
+    Rectangle2D area = new Rectangle2D(0, 0, windowWidth, windowHeight-100);
+    
     private Rectangle createFloor(Scene scene) {
         Rectangle rectangle = new Rectangle(windowWidth, 100);
         rectangle.widthProperty().bind(scene.widthProperty()); //keep as wide as window
@@ -51,11 +71,17 @@ public class Environment extends Application {
     //should use it to make a general menu (File, Edit, Help, etc).
     
     @Override
-    public void start(Stage stage) throws IOException {
-    
-        AnchorPane root = new AnchorPane(); //AnchorPane had better functions then border pane
-        root.setStyle("-fx-background-color: #99F0F5");
-        Scene scene = new Scene(root, windowWidth, windowHeight);   
+    public void start(Stage stage) throws IOException { 	
+        this.root = new AnchorPane(); //AnchorPane had better functions then border pane
+        group = new Group();
+        this.root.setOnMousePressed(me -> select(null));
+	    
+	    Scale scale = new Scale();
+	    group.getTransforms().add(scale);
+	    
+	    scrollPane = new ScrollPane(new Group(root));
+        
+        Scene scene = new Scene(scrollPane, windowWidth, windowHeight);
         
         Rectangle floorRect = createFloor(scene); //floor
         Rectangle sceneRect = new Rectangle(windowWidth, windowHeight); //env range
@@ -63,24 +89,28 @@ public class Environment extends Application {
         sceneRect.heightProperty().bind(scene.heightProperty()); //keep as high as window
         sceneRect.setFill(Color.valueOf("#99F0F5"));
         
-        
+        // set layer and position for of base env
         HBox floor = new HBox(0, floorRect);
+        floor.setViewOrder(2);
         HBox env = new HBox(0, sceneRect);
+        env.setViewOrder(3);
         
         //menu for shapes
         ShapesMenu shapesMenu = new ShapesMenu(); 
-        // shapesMenu.createMenu(scene);
+        shapesMenu.createMenu(scene);
+        HBox sMenu = new HBox(0, shapesMenu.getMenu().shapeVisualizedList);
         HBox tab = new HBox(0, shapesMenu.getTab()); //tab to close menu
-        HBox toolBar = new HBox(0, shapesMenu.toolBar);
+        
         // config layout
-        root.getChildren().addAll(env, floor, toolBar, tab, posReporter, elementInEnvReporter, dragAndDropReporter);
+        root.getChildren().addAll(env, floor, sMenu, tab, 
+        		                  posReporter, elementInEnvReporter, dragAndDropReporter);
         AnchorPane.setBottomAnchor(floor, 0d); // positioning shapes in scene									
-        AnchorPane.setTopAnchor(tab, 160d);
+        AnchorPane.setTopAnchor(tab, 120d);
         AnchorPane.setTopAnchor(posReporter, 680d);
         AnchorPane.setTopAnchor(dragAndDropReporter, 715d);
         AnchorPane.setTopAnchor(elementInEnvReporter, 740d);
         AnchorPane.setLeftAnchor(tab, scene.getWidth()/2.0 - shapesMenu.getTab().getWidth()/2.0);
-        AnchorPane.setTopAnchor(toolBar, 0d);
+        AnchorPane.setTopAnchor(sMenu, 0d);
         
         // track mouse info all the time
         root.setOnMousePressed(e -> {
@@ -131,22 +161,17 @@ public class Environment extends Application {
                 event.consume();
             }
         });
-        floor.setOnDragDropped((DragEvent event) -> {
-        	
-        	
-        });
+
+        
         sceneRect.setOnDragDropped((DragEvent event) -> {
             Dragboard db = event.getDragboard();
-            String shapeInfo = db.getString().replace("[", "!!").replace("]", "!!"); // avoid parsing bug in JAVA 1.8 windows
-//            System.out.println("Select: " + shapeInfo.split("!!")[0]);
+            String shapeInfo = db.getString().replace("[", "!!").replace("]", "!!"); // avoid parsing bug in JAVA 1.8 for windows
             double shapeParam0 = Double.parseDouble(db.getString().split(", ")[2].split("=")[1]);
-            double shapeParam1 = Double.parseDouble(shapeInfo.split(", ")[3].split("=")[0].equals("fill")? "0":shapeInfo.split(", ")[3].split("=")[1]);
-            Dragable newAddedElement = new Dragable(mousePosXTraker, mousePosYTraker, 
-            										Color.web(shapeInfo.split("fill=")[1].split("!!")[0]), 
-            										shapeInfo.split("!!")[0], shapeParam0, shapeParam1);
+            double shapeParam1 = Double.parseDouble(shapeInfo.split(", ")[3].split("=")[0].equals("fill")? "0":shapeInfo.split(", ")[3].split("=")[1]); 
+            Dragable newAddedElement = createElement(mousePosXTraker, mousePosYTraker, shapeParam0, shapeParam1, Color.web(shapeInfo.split("fill=")[1].split("!!")[0]), shapeInfo.split("!!")[0]);
             shapesInEnv.add(newAddedElement);
             elementInEnvReporter.setText("Current element count in env: " + shapesInEnv.size());           
-            root.getChildren().add(newAddedElement.shape);
+            root.getChildren().add(newAddedElement);
             if (db.hasString()) {
             	dragAndDropReporter.setText("Dropped: " + db.getString());
             	dragAndDropReporter.setTextFill(Color.web(shapeInfo.split("fill=")[1].split("!!")[0]));
@@ -157,18 +182,6 @@ public class Environment extends Application {
             event.consume();
         });
         
-//        shapesMenu.getMenu().shapeVisualizedList.getSelectionModel().selectedItemProperty().addListener(
-//	            new ChangeListener<DragAndDropListShape>() {
-//	                public void changed(ObservableValue<? extends DragAndDropListShape> ov, 
-//	                		DragAndDropListShape old_val, DragAndDropListShape new_val) {
-//	                	System.out.println("Current color: "+ new_val.getColor());
-//	                	Dragable newAddedElement = new Dragable(mousePosXTraker, mousePosYTraker, new_val.getColor(), new_val.getShape());
-//	                	shapesInEnv.add(newAddedElement);
-//	                	elementInEnvReporter.setText("Current element count in env: " + shapesInEnv.size());
-//	                	root.getChildren().add(newAddedElement.shape);
-//	            }
-//	     });
-        
         stage.setTitle("GaiNNs");
         stage.setScene(scene);
         stage.show();
@@ -178,7 +191,6 @@ public class Environment extends Application {
         
         
     }
-    
     
     public static void main(String[] args) {
         launch();
@@ -198,4 +210,169 @@ public class Environment extends Application {
     	}
     	
     }
+    
+    void select(Dragable element) {
+        if (this.overlay == null && element != null) iniOverlay();
+        if (element != this.selectedElement) {
+        	this.overlay.setVisible(element != null);
+            // if (element != null) element.toFront();
+            this.selectedElement = element;
+            updateOverlay();
+        }
+    }
+
+    void iniOverlay() {
+    	this.overlay = new Group();
+        //overlay.setVisible(false);
+    	this.srBnd = new Rectangle();
+    	this.srBnd.setStroke(Color.BLACK);
+    	this.srBnd.setStrokeType(StrokeType.INSIDE);
+    	this.srBnd.setStrokeWidth(1);
+    	this.srBnd.getStrokeDashArray().addAll(2d, 4d);
+    	this.srBnd.setFill(Color.TRANSPARENT);
+        handleMouse(this.srBnd);
+        this.srNW = srCreate(Cursor.NW_RESIZE);
+        this.srN = srCreate(Cursor.N_RESIZE);
+        this.srNE = srCreate(Cursor.NE_RESIZE);
+        this.srE = srCreate(Cursor.E_RESIZE);
+        this.srSE = srCreate(Cursor.SE_RESIZE);
+        this.srS = srCreate(Cursor.S_RESIZE);
+        this.srSW = srCreate(Cursor.SW_RESIZE);
+        this.srW = srCreate(Cursor.W_RESIZE);
+        this.overlay.getChildren().addAll(this.srBnd, 
+										  this.srNW, this.srN, 
+										  this.srNE, this.srE, 
+										  this.srSE, this.srS, 
+									      this.srSW, this.srW);
+        this.root.getChildren().add(this.overlay);
+    }
+
+    void updateOverlay() {
+        if (this.selectedElement != null) {
+            this.srBnd.setX(this.selectedElement.getLayoutX());
+            this.srBnd.setY(this.selectedElement.getLayoutY());
+            this.srBnd.setWidth(this.selectedElement.widthProperty().get());
+            this.srBnd.setHeight(this.selectedElement.heightProperty().get());
+            this.srNW.setX(this.selectedElement.getLayoutX());
+            this.srNW.setY(this.selectedElement.getLayoutY());
+            this.srN.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get() / 2) - this.a2);
+            this.srN.setY(this.selectedElement.getLayoutY());
+            this.srNE.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get()) - this.resizeBlockWidth);
+            this.srNE.setY(this.selectedElement.getLayoutY());
+            this.srE.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get()) - this.resizeBlockWidth);
+            this.srE.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get() / 2) - this.a2);
+            this.srSE.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get()) - this.resizeBlockWidth);
+            this.srSE.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get()) - this.resizeBlockWidth);
+            this.srS.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get() / 2) - this.a2);
+            this.srS.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get()) - this.resizeBlockWidth);
+            this.srSW.setX(this.selectedElement.getLayoutX());
+            this.srSW.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get()) - this.resizeBlockWidth);
+            this.srW.setX(this.selectedElement.getLayoutX());
+            this.srW.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get() / 2) - this.a2);
+        }
+      }
+
+    Rectangle srCreate(Cursor cursor) {
+        Rectangle rectangle = new Rectangle(this.resizeBlockWidth, this.resizeBlockWidth, Color.BLACK);
+        rectangle.setCursor(cursor);
+        handleMouse(rectangle);
+        return rectangle;
+     }
+
+    void handleMouse(Node node) {
+        node.setOnMousePressed(me -> {
+        	this.lX = me.getX();
+        	this.lY = me.getY();
+        	this.sX = this.selectedElement.getLayoutX();
+        	this.sY = this.selectedElement.getLayoutY();
+        	this.sWidth = this.selectedElement.widthProperty().get();
+        	this.sHeight = this.selectedElement.heightProperty().get();
+            me.consume();
+        });
+        node.setOnMouseDragged(me -> {
+            double dx = (me.getX() - this.lX);
+            double dy = (me.getY() - this.lY);
+            Object source = me.getSource();
+            if (source == this.srBnd) relocate(this.sX + dx, this.sY + dy);
+            else if (source == this.srNW) { setHSize(this.sX + dx, true); setVSize(this.sY + dy, true); }
+            else if (source == this.srN) setVSize(this.sY + dy, true);
+            else if (source == this.srNE) { setHSize(this.sX + this.sWidth + dx, false); setVSize(this.sY + dy, true); }
+            else if (source == this.srE) setHSize(this.sX + this.sWidth + dx, false);
+            else if (source == this.srSE) { setHSize(this.sX + this.sWidth + dx, false); setVSize(this.sY + this.sHeight + dy, false); }
+            else if (source == this.srS) setVSize(this.sY + this.sHeight + dy, false);
+            else if (source == this.srSW) { setHSize(this.sX + dx, true); setVSize(this.sY + this.sHeight + dy, false); }
+            else if (source == this.srW) setHSize(this.sX + dx, true);
+            me.consume();
+        });
+//        node.setOnMouseReleased(me -> {
+//            Object source = me.getSource();
+//            if (source == this.srBnd) relocate(this.selectedElement.getLayoutX(), this.selectedElement.getLayoutY());
+//            else {
+//                if (source == this.srNW || source == this.srN || source == this.srNE) setVSize(this.selectedElement.getLayoutY(), true);
+//                else if (source == this.srSW || source == this.srS || source == this.srSE) setVSize(this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get(), false);
+//                if (source == this.srNW || source == this.srW || source == this.srSW) setHSize(this.selectedElement.getLayoutX(), true);
+//                else if (source == this.srNE || source == this.srE || source == this.srSE) setHSize(this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get(), false);
+//            }
+//            me.consume();
+//        });
+      }
+
+    void setHSize(double h, boolean b) {
+        double x = this.selectedElement.getLayoutX(), w = this.selectedElement.widthProperty().get(), width;
+        double as = this.resizeBlockWidth * 3;
+        if (h < this.area.getMinX()) h = this.area.getMinX();
+        if (h > this.area.getMaxX()) h = this.area.getMaxX();
+        if (b) {
+          width = w + x - h;
+          if (width < as) { width = as; h = x + w - as; }
+          this.selectedElement.setLayoutX(h);
+        } else {
+          width = h - x;
+          if (width < as) width = as;
+        }
+        this.selectedElement.widthProperty().set(width);
+    }
+
+    // set vertical size
+    void setVSize(double v, boolean b) {
+        double y = this.selectedElement.getLayoutY(), h = this.selectedElement.heightProperty().get(), height;
+        double as = this.resizeBlockWidth * 3;
+        if (v < this.area.getMinY()) v = this.area.getMinY();
+        if (v > this.area.getMaxY()) v = this.area.getMaxY();
+        if (b) {
+          height = h + y - v;
+          if (height < as) { height = as; v = y + h - as; }
+          this.selectedElement.setLayoutY(v);
+        } else {
+          height = v - y;
+          if (height < as) height = as;
+        }
+        this.selectedElement.heightProperty().set(height);
+    }
+
+    // move func
+    public void relocate(double x, double y) {
+        double maxX = this.area.getMaxX() - this.selectedElement.widthProperty().get();
+        double maxY = this.area.getMaxY() - this.selectedElement.heightProperty().get();
+        if (x < this.area.getMinX()) x = this.area.getMinX();
+        if (y < this.area.getMinY()) y = this.area.getMinY();
+        if (x > maxX) x = maxX;
+        if (y > maxY) y = maxY;
+        this.selectedElement.setLayoutX(x);
+        this.selectedElement.setLayoutY(y);
+    }
+
+
+	Dragable createElement(double x, double y, double width, double height, Paint fill, String shapeName) {
+		  Dragable element = new Dragable(x, y, fill, shapeName, width, height);
+	      element.setOnMousePressed(me -> {
+		      select(element);
+		      srBnd.fireEvent(me);
+		      me.consume();
+	      });
+	      element.setOnMouseDragged(me -> srBnd.fireEvent(me));
+	      element.setOnMouseReleased(me -> srBnd.fireEvent(me));
+	      element.boundsInParentProperty().addListener((v, o, n) -> updateOverlay());
+	      return element;
+	 }
 }

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -79,9 +79,9 @@ public class Environment extends Application {
         
         // set layer and position for of base env
         HBox floor = new HBox(0, floorRect);
-        floor.setViewOrder(2);
+        floor.setViewOrder(3);
         HBox env = new HBox(0, sceneRect);
-        env.setViewOrder(3);
+        env.setViewOrder(4);
         
         //menu for shapes
         ShapesMenu shapesMenu = new ShapesMenu(); 
@@ -94,9 +94,9 @@ public class Environment extends Application {
         		                  posReporter, elementInEnvReporter, dragAndDropReporter);
         AnchorPane.setBottomAnchor(floor, 0d); // positioning shapes in scene									
         AnchorPane.setTopAnchor(tab, 120d);
-        AnchorPane.setTopAnchor(posReporter, 680d);
-        AnchorPane.setTopAnchor(dragAndDropReporter, 715d);
-        AnchorPane.setTopAnchor(elementInEnvReporter, 740d);
+        AnchorPane.setBottomAnchor(posReporter, 65d);
+        AnchorPane.setBottomAnchor(dragAndDropReporter, 50d);
+        AnchorPane.setBottomAnchor(elementInEnvReporter, 0d);
         AnchorPane.setLeftAnchor(tab, scene.getWidth()/2.0 - shapesMenu.getTab().getWidth()/2.0);
         AnchorPane.setTopAnchor(sMenu, 0d);
         
@@ -234,6 +234,7 @@ public class Environment extends Application {
 										  this.srSE, this.srS, 
 									      this.srSW, this.srW);
         this.root.getChildren().add(this.overlay);
+        this.overlay.setViewOrder(1);
     }
 
     void updateOverlay() {
@@ -345,6 +346,7 @@ public class Environment extends Application {
 		  Dragable element = new Dragable(x, y, fill, shapeName, width, height);
 	      element.setOnMousePressed(me -> {
 		      select(element);
+		      element.setViewOrder(2);
 		      srBnd.fireEvent(me);
 		      me.consume();
 	      });

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -69,19 +69,18 @@ public class Environment extends Application {
         
         //menu for shapes
         ShapesMenu shapesMenu = new ShapesMenu(); 
-        shapesMenu.createMenu(scene);
-        HBox sMenu = new HBox(0, shapesMenu.getMenu().shapeVisualizedList);
+        // shapesMenu.createMenu(scene);
         HBox tab = new HBox(0, shapesMenu.getTab()); //tab to close menu
-        
+        HBox toolBar = new HBox(0, shapesMenu.toolBar);
         // config layout
-        root.getChildren().addAll(env, floor, sMenu, tab, posReporter, elementInEnvReporter, dragAndDropReporter);
+        root.getChildren().addAll(env, floor, toolBar, tab, posReporter, elementInEnvReporter, dragAndDropReporter);
         AnchorPane.setBottomAnchor(floor, 0d); // positioning shapes in scene									
-        AnchorPane.setTopAnchor(tab, 120d);
+        AnchorPane.setTopAnchor(tab, 160d);
         AnchorPane.setTopAnchor(posReporter, 680d);
         AnchorPane.setTopAnchor(dragAndDropReporter, 715d);
         AnchorPane.setTopAnchor(elementInEnvReporter, 740d);
         AnchorPane.setLeftAnchor(tab, scene.getWidth()/2.0 - shapesMenu.getTab().getWidth()/2.0);
-        AnchorPane.setTopAnchor(sMenu, 0d);
+        AnchorPane.setTopAnchor(toolBar, 0d);
         
         // track mouse info all the time
         root.setOnMousePressed(e -> {

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -29,13 +29,11 @@ import java.util.List;
 
 
 public class Environment extends Application {
-	double resizeBlockWidth = 6, a2 = resizeBlockWidth / 2;
-    double gridSize = -1;
+	double resizeBlockWidth = 6, resizeBlockWidthOffset = resizeBlockWidth / 2;
     double lastX, lastY;
     double lX, lY, sX, sY, sWidth, sHeight;
     ScrollPane scrollPane;
-    Group group, overlay = null;
-    
+    Group overlay = null;
     
     // scale change point
     Rectangle srBnd, srNW, srN, srNE, srE, srSE, srS, srSW, srW;
@@ -48,6 +46,7 @@ public class Environment extends Application {
 	final Label posReporter = new Label();
 	final Label elementInEnvReporter = new Label();
 	final Label dragAndDropReporter = new Label();
+	
 	// mouse tracker
 	private double mousePosXTraker = 0;
 	private double mousePosYTraker = 0;
@@ -73,15 +72,9 @@ public class Environment extends Application {
     @Override
     public void start(Stage stage) throws IOException { 	
         this.root = new AnchorPane(); //AnchorPane had better functions then border pane
-        group = new Group();
         this.root.setOnMousePressed(me -> select(null));
-	    
-	    Scale scale = new Scale();
-	    group.getTransforms().add(scale);
-	    
-	    scrollPane = new ScrollPane(new Group(root));
         
-        Scene scene = new Scene(scrollPane, windowWidth, windowHeight);
+        Scene scene = new Scene(root, windowWidth, windowHeight);
         
         Rectangle floorRect = createFloor(scene); //floor
         Rectangle sceneRect = new Rectangle(windowWidth, windowHeight); //env range
@@ -223,7 +216,7 @@ public class Environment extends Application {
 
     void iniOverlay() {
     	this.overlay = new Group();
-        //overlay.setVisible(false);
+        // overlay.setVisible(false);
     	this.srBnd = new Rectangle();
     	this.srBnd.setStroke(Color.BLACK);
     	this.srBnd.setStrokeType(StrokeType.INSIDE);
@@ -255,20 +248,20 @@ public class Environment extends Application {
             this.srBnd.setHeight(this.selectedElement.heightProperty().get());
             this.srNW.setX(this.selectedElement.getLayoutX());
             this.srNW.setY(this.selectedElement.getLayoutY());
-            this.srN.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get() / 2) - this.a2);
+            this.srN.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get() / 2) - this.resizeBlockWidthOffset);
             this.srN.setY(this.selectedElement.getLayoutY());
             this.srNE.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get()) - this.resizeBlockWidth);
             this.srNE.setY(this.selectedElement.getLayoutY());
             this.srE.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get()) - this.resizeBlockWidth);
-            this.srE.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get() / 2) - this.a2);
+            this.srE.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get() / 2) - this.resizeBlockWidthOffset);
             this.srSE.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get()) - this.resizeBlockWidth);
             this.srSE.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get()) - this.resizeBlockWidth);
-            this.srS.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get() / 2) - this.a2);
+            this.srS.setX((this.selectedElement.getLayoutX() + this.selectedElement.widthProperty().get() / 2) - this.resizeBlockWidthOffset);
             this.srS.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get()) - this.resizeBlockWidth);
             this.srSW.setX(this.selectedElement.getLayoutX());
             this.srSW.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get()) - this.resizeBlockWidth);
             this.srW.setX(this.selectedElement.getLayoutX());
-            this.srW.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get() / 2) - this.a2);
+            this.srW.setY((this.selectedElement.getLayoutY() + this.selectedElement.heightProperty().get() / 2) - this.resizeBlockWidthOffset);
         }
       }
 

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -9,7 +9,6 @@ import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.InputEvent;
@@ -87,6 +86,7 @@ public class Environment extends Application {
         ShapesMenu shapesMenu = new ShapesMenu(); 
         shapesMenu.createMenu(scene);
         HBox sMenu = new HBox(0, shapesMenu.getMenu().shapeVisualizedList);
+        sMenu.setPickOnBounds(false);
         HBox tab = new HBox(0, shapesMenu.getTab()); //tab to close menu
         
         // config layout

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -9,10 +9,13 @@ import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
+import javafx.scene.control.Slider;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 //import javafx.animation.Transition.*;
 import javafx.util.Duration;
@@ -30,18 +33,16 @@ import javafx.util.Callback;
 
 public class ShapesMenu {
 	
-		// private Rectangle menu = new Rectangle();
-		private shapeContainer items = new shapeContainer();
-		private Button tab = new Button("HIDE");
-		private boolean hidden = false;
+	private shapeContainer items;
+	private Button tab;
+	private boolean hidden = false;
+	public VBox toolBar;
 	
-	public void createMenu(Scene scene) { //set up shape proportions and color for menu
-//		menu.setWidth(1500);
-//		menu.setHeight(120);
-//		menu.widthProperty().bind(scene.widthProperty());
-//		menu.setFill(Color.valueOf("#4C4C4C"));
-//		tab.setStyle("-fx-background-color: #4C4C4C; -fx-text-fill: #FFFFFF");
-		
+	public ShapesMenu() {
+		this.items = new shapeContainer();
+		this.tab = new Button("HIDE");
+		this.toolBar = new VBox();
+		toolBar.getChildren().addAll(items.shapeVisualizedList, items.sliderForDraggableShape);
 	}
 	public shapeContainer getMenu() {
 		return items;
@@ -51,7 +52,7 @@ public class ShapesMenu {
 	}	
 	
 	public boolean tabPressed() { // if tab pressed
-		TranslateTransition tt = new TranslateTransition(Duration.millis(250), this.items.shapeVisualizedList);
+		TranslateTransition tt = new TranslateTransition(Duration.millis(250), this.toolBar);
 		if(hidden) {
 			//menu.setHeight(120);
 			tt.setByY(120f);
@@ -79,6 +80,8 @@ public class ShapesMenu {
 
 class shapeContainer {
 	public ListView<DragAndDropListShape> shapeVisualizedList;
+	public Slider sliderForDraggableShape = new Slider(0, 1, 0.5);
+	
 	@SuppressWarnings("unchecked")
 	ObservableList<DragAndDropListShape> data = FXCollections.observableArrayList(new DragAndDropListShape(new Circle(20), Color.BLUE), 
 																				new DragAndDropListShape(new Rectangle(50, 50), Color.RED), 
@@ -107,6 +110,13 @@ class shapeContainer {
 	final Label label = new Label();
 	
 	public shapeContainer() {
+		// slider for shape
+		sliderForDraggableShape.setShowTickMarks(true);
+		sliderForDraggableShape.setShowTickLabels(true);
+		sliderForDraggableShape.setMajorTickUnit(0.25f);
+		sliderForDraggableShape.setBlockIncrement(0.1f);
+		
+		// list shape
 		this.shapeVisualizedList = new ListView<>();	
 		shapeVisualizedList.setItems(data);
 		shapeVisualizedList.setPrefWidth(Screen.getPrimary().getBounds().getWidth() - 400);  // TO-DO: make change?
@@ -120,12 +130,12 @@ class shapeContainer {
 		
 		shapeVisualizedList.setCellFactory(new Callback<ListView<DragAndDropListShape>, 
 				                                        ListCell<DragAndDropListShape>>() {
-	                @Override 
-	                public ListCell<DragAndDropListShape> call(ListView<DragAndDropListShape> list) {
-	                    return new ColorCell();
-	                }
-	            }
-	        );
+                @Override 
+                public ListCell<DragAndDropListShape> call(ListView<DragAndDropListShape> list) {
+                    return new ColorCell();
+                }
+            }
+        );
 	 
 		shapeVisualizedList.getSelectionModel().selectedItemProperty().addListener(
 	            new ChangeListener<DragAndDropListShape>() {

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -9,13 +9,10 @@ import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
-import javafx.scene.control.Slider;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
-import javafx.scene.layout.Pane;
-import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 //import javafx.animation.Transition.*;
 import javafx.util.Duration;
@@ -33,17 +30,20 @@ import javafx.util.Callback;
 
 public class ShapesMenu {
 	
-	private shapeContainer items;
-	private Button tab;
-	private boolean hidden = false;
-	public VBox toolBar;
+		// private Rectangle menu = new Rectangle();
+		private shapeContainer items = new shapeContainer();
+		private Button tab = new Button("HIDE");
+		private boolean hidden = false;
 	
-	public ShapesMenu() {
-		this.items = new shapeContainer();
-		this.tab = new Button("HIDE");
-		this.toolBar = new VBox();
-		toolBar.getChildren().addAll(items.shapeVisualizedList, items.sliderForDraggableShape);
+	public void createMenu(Scene scene) { //set up shape proportions and color for menu
+//		menu.setWidth(1500);
+//		menu.setHeight(120);
+//		menu.widthProperty().bind(scene.widthProperty());
+//		menu.setFill(Color.valueOf("#4C4C4C"));
+//		tab.setStyle("-fx-background-color: #4C4C4C; -fx-text-fill: #FFFFFF");
+		
 	}
+
 	public shapeContainer getMenu() {
 		return items;
 	}
@@ -52,7 +52,7 @@ public class ShapesMenu {
 	}	
 	
 	public boolean tabPressed() { // if tab pressed
-		TranslateTransition tt = new TranslateTransition(Duration.millis(250), this.toolBar);
+		TranslateTransition tt = new TranslateTransition(Duration.millis(250), this.items.shapeVisualizedList);
 		if(hidden) {
 			//menu.setHeight(120);
 			tt.setByY(120f);
@@ -80,8 +80,6 @@ public class ShapesMenu {
 
 class shapeContainer {
 	public ListView<DragAndDropListShape> shapeVisualizedList;
-	public Slider sliderForDraggableShape = new Slider(0, 1, 0.5);
-	
 	@SuppressWarnings("unchecked")
 	ObservableList<DragAndDropListShape> data = FXCollections.observableArrayList(new DragAndDropListShape(new Circle(20), Color.BLUE), 
 																				new DragAndDropListShape(new Rectangle(50, 50), Color.RED), 
@@ -110,13 +108,6 @@ class shapeContainer {
 	final Label label = new Label();
 	
 	public shapeContainer() {
-		// slider for shape
-		sliderForDraggableShape.setShowTickMarks(true);
-		sliderForDraggableShape.setShowTickLabels(true);
-		sliderForDraggableShape.setMajorTickUnit(0.25f);
-		sliderForDraggableShape.setBlockIncrement(0.1f);
-		
-		// list shape
 		this.shapeVisualizedList = new ListView<>();	
 		shapeVisualizedList.setItems(data);
 		shapeVisualizedList.setPrefWidth(Screen.getPrimary().getBounds().getWidth() - 400);  // TO-DO: make change?
@@ -130,12 +121,12 @@ class shapeContainer {
 		
 		shapeVisualizedList.setCellFactory(new Callback<ListView<DragAndDropListShape>, 
 				                                        ListCell<DragAndDropListShape>>() {
-                @Override 
-                public ListCell<DragAndDropListShape> call(ListView<DragAndDropListShape> list) {
-                    return new ColorCell();
-                }
-            }
-        );
+	                @Override 
+	                public ListCell<DragAndDropListShape> call(ListView<DragAndDropListShape> list) {
+	                    return new ColorCell();
+	                }
+	            }
+	        );
 	 
 		shapeVisualizedList.getSelectionModel().selectedItemProperty().addListener(
 	            new ChangeListener<DragAndDropListShape>() {

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -16,15 +16,12 @@ import javafx.scene.input.TransferMode;
 import javafx.scene.paint.Color;
 //import javafx.animation.Transition.*;
 import javafx.util.Duration;
-import javafx.util.Pair;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.ListCell;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.shape.Shape;
-import javafx.scene.text.Text;
 import javafx.stage.Screen;
 import javafx.util.Callback;
 
@@ -47,6 +44,7 @@ public class ShapesMenu {
 	public shapeContainer getMenu() {
 		return items;
 	}
+	
 	public Button getTab() {
 		return tab;
 	}	

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -188,4 +188,3 @@ class shapeContainer {
 //		primaryStage.setScene(scene);
 //		primaryStage.show();
 //	}
-


### PR DESCRIPTION
Added the function of shape scaling. Shapes can now form six locus points on the outside by clicking, and users can drag the locus points to scale the shape.
![image](https://user-images.githubusercontent.com/31975605/179373872-48b8db6f-b10a-42dc-92e5-e3a4df678fe3.png)

Fixed an issue where shapes could be dragged below the floor as well as outside the environment. Now it will stop when encountering an edge (whether it is the floor below or the edge of the window) during a drag-and-drop or scaling operation.

(also merged existing solutions from Zhi and Ryan on the "shape above menu" issue)