### PR TITLE
Initializing Menu Buttons

### DIFF
--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -265,9 +265,12 @@ public class Environment extends Application {
         stage.setMinHeight(600);
         stage.setMinWidth(800);
         stage.show();
+        
+        root.setLeftAnchor(tab, ((double) stage.getWidth())/2.0);
+        root.setLeftAnchor(changeMenu, ((double) stage.getWidth())/2.0 - shapesMenu.getChangeMenuTab().getWidth());
         stage.widthProperty().addListener((obs, oldVal, newVal) -> { // change pos of button(tab) when window changes
     		AnchorPane.setLeftAnchor(tab, ((double)newVal)/2.0);
-        AnchorPane.setLeftAnchor(changeMenu, ((double)newVal)/2.0 - shapesMenu.getChangeMenuTab().getWidth());
+    		AnchorPane.setLeftAnchor(changeMenu, ((double)newVal)/2.0 - shapesMenu.getChangeMenuTab().getWidth());
     	});
         gameLoop.start();
     }

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -88,6 +88,7 @@ public class ShapesMenu {
 			tt.play();
 			hidden = true;
 			tab.setText("SHOW");
+			this.items.shapeVisualizedList.getSelectionModel().clearSelection();
 		}
 
 		return hidden;
@@ -137,7 +138,7 @@ class shapeContainer {
 	                }
 	            }
 	        );
-	 
+		
 		shapeVisualizedList.getSelectionModel().selectedItemProperty().addListener(
 	            new ChangeListener<DragAndDropListShape>() {
 	                public void changed(ObservableValue<? extends DragAndDropListShape> ov, 

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -79,10 +79,6 @@ public class ShapesMenu {
 			tt.play();
 			hidden = false;
 			tab.setText("HIDE");
-			
-//			if (selectedIndex != null){
-//				this.items.shapeVisualizedList.getSelectionModel().select(selectedIndex);
-//			}
 		}
 		else {
 			//menu.setHeight(0);
@@ -93,9 +89,7 @@ public class ShapesMenu {
 			hidden = true;
 			tab.setText("SHOW");
 			
-			// deselect the selected element when hiding menu. Also remember the last selected element
-//			selectedIndex = this.items.shapeVisualizedList.getSelectionModel().getSelectedIndex(); 
-			this.items.shapeVisualizedList.getSelectionModel().clearSelection();
+//			this.items.shapeVisualizedList.getSelectionModel().clearSelection();
 		}
 
 		return hidden;

--- a/src/main/java/com/example/gainns/ShapesMenu.java
+++ b/src/main/java/com/example/gainns/ShapesMenu.java
@@ -34,7 +34,7 @@ public class ShapesMenu {
 		private Button changeMenu = new Button("Scene Editor");
 		private boolean hidden = false;
 		private boolean charMenuShowing = true;
-	
+		
 	public void createMenu(Scene scene) { //set up shape proportions and color for menu
 //		menu.setWidth(1500);
 //		menu.setHeight(120);
@@ -79,6 +79,10 @@ public class ShapesMenu {
 			tt.play();
 			hidden = false;
 			tab.setText("HIDE");
+			
+//			if (selectedIndex != null){
+//				this.items.shapeVisualizedList.getSelectionModel().select(selectedIndex);
+//			}
 		}
 		else {
 			//menu.setHeight(0);
@@ -88,6 +92,9 @@ public class ShapesMenu {
 			tt.play();
 			hidden = true;
 			tab.setText("SHOW");
+			
+			// deselect the selected element when hiding menu. Also remember the last selected element
+//			selectedIndex = this.items.shapeVisualizedList.getSelectionModel().getSelectedIndex(); 
 			this.items.shapeVisualizedList.getSelectionModel().clearSelection();
 		}
 


### PR DESCRIPTION
Fixed a bug. The app used to start with the changeMenu button on top of the hide menu button. Because these buttons are not initialized to line up, but they do when window is resized
After discussion with Yuetian (Mom), we decided that this issue actually shouldn't be an issue since the "bug" is actually a standard feature.