### PR TITLE
Copy and paste shapes

### DIFF
--- a/src/main/java/com/example/gainns/DragableShape.java
+++ b/src/main/java/com/example/gainns/DragableShape.java
@@ -61,11 +61,11 @@ class Dragable extends Group {
     	if (this.myShapeName.equals("Rectangle")) {
 			this.widthProperty.addListener((v, o, n) -> { rectangle.setWidth(n.doubleValue()); });
 		    this.heightProperty.addListener((v, o, n) -> { rectangle.setHeight(n.doubleValue()); });
-		    setLayoutX(x);
-		    setLayoutY(y);
+		    this.setLayoutX(x);
+		    this.setLayoutY(y);
 		    this.widthProperty.set(copied_element.rectangle.widthProperty().doubleValue());
 		    this.heightProperty.set(copied_element.rectangle.heightProperty().doubleValue());
-		    this.ellipse.setFill(copied_element.rectangle.getFill());
+		    this.rectangle.setFill(copied_element.rectangle.getFill());
 		    this.getChildren().add(rectangle);
 		    
 		    // set transparency during moving
@@ -75,8 +75,8 @@ class Dragable extends Group {
 		} else if (this.myShapeName.equals("Ellipse")) {
 			this.widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
 			this.heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
-		    setLayoutX(x);
-		    setLayoutY(y);
+			this.setLayoutX(x);
+		    this.setLayoutY(y);
 		    this.widthProperty.set(copied_element.ellipse.getRadiusX() * 2);
 		    this.heightProperty.set(copied_element.ellipse.getRadiusY() * 2);
 		    this.ellipse.setFill(copied_element.ellipse.getFill());
@@ -90,8 +90,8 @@ class Dragable extends Group {
 			
 			this.widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
 			this.heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
-		    setLayoutX(x);
-		    setLayoutY(y);
+			this.setLayoutX(x);
+		    this.setLayoutY(y);
 		    this.widthProperty.set(copied_element.ellipse.getRadiusY() * 2);
 		    this.heightProperty.set(copied_element.ellipse.getRadiusY() * 2);
 		    this.ellipse.setFill(copied_element.ellipse.getFill());
@@ -108,9 +108,9 @@ class Dragable extends Group {
     	this.heightProperty = new SimpleDoubleProperty();
     	this.heightProperty.set(copied_element.heightProperty.doubleValue());
     	
-    	this.rotataionDegree = copied_element.rotataionDegree;
-        this.rotationLengthOffsetY = copied_element.rotationLengthOffsetY;
-        this.rotationLengthOffsetX = copied_element.rotationLengthOffsetX;  	
+    	this.rotataionDegree = 0;
+        this.rotationLengthOffsetY = 0;
+        this.rotationLengthOffsetX = 0;  	
     }
     public String getShapeName() {
     	return new String( myShapeName );

--- a/src/main/java/com/example/gainns/DragableShape.java
+++ b/src/main/java/com/example/gainns/DragableShape.java
@@ -55,7 +55,62 @@ class Dragable extends Group {
     // Copy constructor
     Dragable(double x, double y, Dragable copied_element){
     	this.myShapeName = new String(copied_element.myShapeName);
+    	this.rectangle = new Rectangle();
+    	this.ellipse = new Ellipse();
     	
+    	if (this.myShapeName.equals("Rectangle")) {
+			this.widthProperty.addListener((v, o, n) -> { rectangle.setWidth(n.doubleValue()); });
+		    this.heightProperty.addListener((v, o, n) -> { rectangle.setHeight(n.doubleValue()); });
+		    setLayoutX(x);
+		    setLayoutY(y);
+		    this.widthProperty.set(copied_element.rectangle.widthProperty().doubleValue());
+		    this.heightProperty.set(copied_element.rectangle.heightProperty().doubleValue());
+		    this.ellipse.setFill(copied_element.rectangle.getFill());
+		    this.getChildren().add(rectangle);
+		    
+		    // set transparency during moving
+		    this.rectangle.setOnMouseDragged(me -> rectangle.setOpacity(0.7));
+		    this.rectangle.setOnMouseReleased(me -> rectangle.setOpacity(1));
+		    
+		} else if (this.myShapeName.equals("Ellipse")) {
+			this.widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
+			this.heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
+		    setLayoutX(x);
+		    setLayoutY(y);
+		    this.widthProperty.set(copied_element.ellipse.getRadiusX() * 2);
+		    this.heightProperty.set(copied_element.ellipse.getRadiusY() * 2);
+		    this.ellipse.setFill(copied_element.ellipse.getFill());
+		    getChildren().add(ellipse);
+		    
+		    // set transparency during moving
+		    this.ellipse.setOnMouseDragged(me -> ellipse.setOpacity(0.7));
+		    this.ellipse.setOnMouseReleased(me ->ellipse.setOpacity(1));
+		    
+		} else if (this.myShapeName.equals("Circle")) {
+			
+			this.widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
+			this.heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
+		    setLayoutX(x);
+		    setLayoutY(y);
+		    this.widthProperty.set(copied_element.ellipse.getRadiusY() * 2);
+		    this.heightProperty.set(copied_element.ellipse.getRadiusY() * 2);
+		    this.ellipse.setFill(copied_element.ellipse.getFill());
+		    getChildren().add(ellipse);
+		    
+		    // set transparency during moving
+		    this.ellipse.setOnMouseDragged(me -> ellipse.setOpacity(0.7));
+		    this.ellipse.setOnMouseReleased(me ->ellipse.setOpacity(1));
+		}
+    	
+    	this.widthProperty = new SimpleDoubleProperty();
+    	this.widthProperty.set(copied_element.widthProperty.doubleValue());
+    	
+    	this.heightProperty = new SimpleDoubleProperty();
+    	this.heightProperty.set(copied_element.heightProperty.doubleValue());
+    	
+    	this.rotataionDegree = copied_element.rotataionDegree;
+        this.rotationLengthOffsetY = copied_element.rotationLengthOffsetY;
+        this.rotationLengthOffsetX = copied_element.rotationLengthOffsetX;  	
     }
     public String getShapeName() {
     	return new String( myShapeName );

--- a/src/main/java/com/example/gainns/DragableShape.java
+++ b/src/main/java/com/example/gainns/DragableShape.java
@@ -101,10 +101,10 @@ class Dragable extends Group {
 		    this.ellipse.setOnMouseDragged(me -> this.ellipse.setOpacity(0.7));
 		    this.ellipse.setOnMouseReleased(me -> this.ellipse.setOpacity(1));
 		}
-    	
-    	this.rotataionDegree = copied_element.rotataionDegree;
-        this.rotationLengthOffsetY = copied_element.rotationLengthOffsetX;
-        this.rotationLengthOffsetX = copied_element.rotationLengthOffsetY;  	
+    	  	
+    	this.setRotate(copied_element.rotataionDegree, true);
+    	this.setRotationLengthOffsetX(copied_element.rotationLengthOffsetX);
+    	this.setRotationLengthOffsetY(copied_element.rotationLengthOffsetY);
     }
     public String getShapeName() {
     	return new String( myShapeName );

--- a/src/main/java/com/example/gainns/DragableShape.java
+++ b/src/main/java/com/example/gainns/DragableShape.java
@@ -59,58 +59,52 @@ class Dragable extends Group {
     	this.ellipse = new Ellipse();
     	
     	if (this.myShapeName.equals("Rectangle")) {
-			this.widthProperty.addListener((v, o, n) -> { rectangle.setWidth(n.doubleValue()); });
-		    this.heightProperty.addListener((v, o, n) -> { rectangle.setHeight(n.doubleValue()); });
+			this.widthProperty.addListener((v, o, n) -> { this.rectangle.setWidth(n.doubleValue()); });
+		    this.heightProperty.addListener((v, o, n) -> { this.rectangle.setHeight(n.doubleValue()); });
 		    this.setLayoutX(x);
 		    this.setLayoutY(y);
 		    this.widthProperty.set(copied_element.rectangle.widthProperty().doubleValue());
 		    this.heightProperty.set(copied_element.rectangle.heightProperty().doubleValue());
 		    this.rectangle.setFill(copied_element.rectangle.getFill());
-		    this.getChildren().add(rectangle);
+		    this.getChildren().add(this.rectangle);
 		    
 		    // set transparency during moving
-		    this.rectangle.setOnMouseDragged(me -> rectangle.setOpacity(0.7));
-		    this.rectangle.setOnMouseReleased(me -> rectangle.setOpacity(1));
+		    this.rectangle.setOnMouseDragged(me -> this.rectangle.setOpacity(0.7));
+		    this.rectangle.setOnMouseReleased(me -> this.rectangle.setOpacity(1));
 		    
 		} else if (this.myShapeName.equals("Ellipse")) {
-			this.widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
-			this.heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
+			this.widthProperty.addListener((v, o, n) -> { this.ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
+			this.heightProperty.addListener((v, o, n) -> { this.ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
 			this.setLayoutX(x);
 		    this.setLayoutY(y);
 		    this.widthProperty.set(copied_element.ellipse.getRadiusX() * 2);
 		    this.heightProperty.set(copied_element.ellipse.getRadiusY() * 2);
 		    this.ellipse.setFill(copied_element.ellipse.getFill());
-		    getChildren().add(ellipse);
+		    getChildren().add(this.ellipse);
 		    
 		    // set transparency during moving
-		    this.ellipse.setOnMouseDragged(me -> ellipse.setOpacity(0.7));
-		    this.ellipse.setOnMouseReleased(me ->ellipse.setOpacity(1));
+		    this.ellipse.setOnMouseDragged(me -> this.ellipse.setOpacity(0.7));
+		    this.ellipse.setOnMouseReleased(me -> this.ellipse.setOpacity(1));
 		    
 		} else if (this.myShapeName.equals("Circle")) {
 			
-			this.widthProperty.addListener((v, o, n) -> { ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
-			this.heightProperty.addListener((v, o, n) -> { ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
+			this.widthProperty.addListener((v, o, n) -> { this.ellipse.setRadiusX(n.doubleValue()/2); ellipse.setCenterX(n.doubleValue()/2);});
+			this.heightProperty.addListener((v, o, n) -> { this.ellipse.setRadiusY(n.doubleValue()/2); ellipse.setCenterY(n.doubleValue()/2);});
 			this.setLayoutX(x);
 		    this.setLayoutY(y);
 		    this.widthProperty.set(copied_element.ellipse.getRadiusY() * 2);
 		    this.heightProperty.set(copied_element.ellipse.getRadiusY() * 2);
 		    this.ellipse.setFill(copied_element.ellipse.getFill());
-		    getChildren().add(ellipse);
+		    getChildren().add(this.ellipse);
 		    
 		    // set transparency during moving
-		    this.ellipse.setOnMouseDragged(me -> ellipse.setOpacity(0.7));
-		    this.ellipse.setOnMouseReleased(me ->ellipse.setOpacity(1));
+		    this.ellipse.setOnMouseDragged(me -> this.ellipse.setOpacity(0.7));
+		    this.ellipse.setOnMouseReleased(me -> this.ellipse.setOpacity(1));
 		}
     	
-    	this.widthProperty = new SimpleDoubleProperty();
-    	this.widthProperty.set(copied_element.widthProperty.doubleValue());
-    	
-    	this.heightProperty = new SimpleDoubleProperty();
-    	this.heightProperty.set(copied_element.heightProperty.doubleValue());
-    	
-    	this.rotataionDegree = 0;
-        this.rotationLengthOffsetY = 0;
-        this.rotationLengthOffsetX = 0;  	
+    	this.rotataionDegree = copied_element.rotataionDegree;
+        this.rotationLengthOffsetY = copied_element.rotationLengthOffsetX;
+        this.rotationLengthOffsetX = copied_element.rotationLengthOffsetY;  	
     }
     public String getShapeName() {
     	return new String( myShapeName );

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -106,12 +106,8 @@ public class Environment extends Application {
         Scene scene = new Scene(root, windowWidth, windowHeight);
         // Listen for keys
         handleKeyboardShortcut(scene);
-        scene.setOnKeyPressed(e -> {
-        	pressedKeys.add(e.getCode());
-        });
-        scene.setOnKeyReleased(e -> {
-        	pressedKeys.remove(e.getCode());        	
-        });
+                
+        this.handleKeyboardShortcut(scene);
         
         Rectangle floorRect = createFloor(scene); //floor
         org.dyn4j.geometry.Rectangle physicsRect = new org.dyn4j.geometry.Rectangle(20, 1);//(floorRect.getWidth()/Settings.SCALE, floorRect.getHeight()/Settings.SCALE);
@@ -252,7 +248,7 @@ public class Environment extends Application {
         // Copy shape
         KeyCombination copyShapeKeyCombo = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
         Runnable copyShapeRunnable = () -> {
-        	boolean DEBUG = true;
+        	boolean DEBUG = false;
         	if (DEBUG) System.out.println("Accelerator Ctrl + C pressed");
         	
         	if (this.selectedElement != null) {
@@ -269,7 +265,7 @@ public class Environment extends Application {
         // Paste shape
         KeyCombination pasteShapeKeyCombo = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
         Runnable pasteShapeRunnable = () -> {
-        	boolean DEBUG = true;
+        	boolean DEBUG = false;
         	if (DEBUG) System.out.println("Accelerator Ctrl + V pressed");
         	// first, create a deep copy of the copied shape using the reference to the old shape
         	Dragable pastingShape = createElement(mousePosXTraker, mousePosYTraker, copiedShape);
@@ -287,10 +283,12 @@ public class Environment extends Application {
             String shapeInfo = db.getString().replace("[", "!!").replace("]", "!!"); // avoid parsing bug in JAVA 1.8 for windows
             double shapeParam0 = Double.parseDouble(db.getString().split(", ")[2].split("=")[1]);
             double shapeParam1 = Double.parseDouble(shapeInfo.split(", ")[3].split("=")[0].equals("fill")? "0":shapeInfo.split(", ")[3].split("=")[1]); 
+            
             Dragable newAddedElement = createElement(mousePosXTraker, mousePosYTraker, shapeParam0, shapeParam1, Color.web(shapeInfo.split("fill=")[1].split("!!")[0]), shapeInfo.split("!!")[0]);
             shapesInEnv.add(newAddedElement);
             elementInEnvReporter.setText("Current element count in env: " + shapesInEnv.size());           
             root.getChildren().add(newAddedElement);
+            
             if (db.hasString()) {
             	dragAndDropReporter.setText("Dropped: " + db.getString());
             	dragAndDropReporter.setTextFill(Color.web(shapeInfo.split("fill=")[1].split("!!")[0]));
@@ -308,8 +306,8 @@ public class Environment extends Application {
         stage.setMinWidth(800);
         stage.show();
         
-        root.setLeftAnchor(tab, ((double) stage.getWidth())/2.0);
-        root.setLeftAnchor(changeMenu, ((double) stage.getWidth())/2.0 - shapesMenu.getChangeMenuTab().getWidth());
+        AnchorPane.setLeftAnchor(tab, ((double) stage.getWidth())/2.0);
+        AnchorPane.setLeftAnchor(changeMenu, ((double) stage.getWidth())/2.0 - shapesMenu.getChangeMenuTab().getWidth());
         stage.widthProperty().addListener((obs, oldVal, newVal) -> { // change pos of button(tab) when window changes
     		AnchorPane.setLeftAnchor(tab, ((double)newVal)/2.0);
     		AnchorPane.setLeftAnchor(changeMenu, ((double)newVal)/2.0 - shapesMenu.getChangeMenuTab().getWidth());
@@ -318,35 +316,41 @@ public class Environment extends Application {
     }
     
     private void handleKeyboardShortcut(Scene scene) {
+    	boolean DEBUG = false;
+    	
     	scene.setOnKeyPressed(new EventHandler<KeyEvent>() {
-            KeyCombination copyCombo = new KeyCharacterCombination("c", KeyCombination.CONTROL_DOWN);
-            KeyCombination pasteCombo = new KeyCharacterCombination("v", KeyCombination.CONTROL_DOWN);
+//    		KeyCombination copyShapeKeyCombo = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
+//    		KeyCombination pasteShapeKeyCombo = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
             // KeyCombination codeCombo = new KeyCodeCombination(KeyCode.P, KeyCombination.CONTROL_DOWN);
 
             @Override
             public void handle(KeyEvent event) {
-                if (copyCombo.match(event)) {
-                    System.out.println("Press copy");
-                }else if (pasteCombo.match(event)) {
-                    System.out.println("Press paste");
-                }
+//                if (copyShapeKeyCombo.match(event)) {
+//                    System.out.println("Ctrl + C pressed");
+//                } 
+//                if (pasteShapeKeyCombo.match(event)) {
+//                    System.out.println("Ctrl + V pressed");
+//                }
                 if (event.getCode() == KeyCode.DELETE && selectedElement != null) {
-            		System.out.println("DELETE pressed");
+            		if (DEBUG) System.out.println("DELETE pressed");
             		root.getChildren().remove(overlay);
             		root.getChildren().remove(selectedElement);
             		shapesInEnv.remove(selectedElement);
             		overlay = null;
             		selectedElement = null;
             	}
-                if (event.getCode() == KeyCode.SHIFT) {
-                	System.out.println("Press shift");
-                }
+                pressedKeys.add(event.getCode());
             }
         }); 
-        scene.setOnKeyReleased(e -> System.out.println("released"));
+    	
+        scene.setOnKeyReleased(e -> {
+        	pressedKeys.remove(e.getCode());
+        	if (DEBUG) System.out.println("released");
+        });
         
 		
 	}
+
 
 	public static void main(String[] args) {
         launch();
@@ -586,6 +590,7 @@ public class Environment extends Application {
             else if (source == this.srW) setHSize(this.shapeLayoutX + dx, true);
             else if (source == this.srCen) setCenter(this.shapeLayoutX + dx, this.shapeLayoutY + dy);
             else if (source == this.srRotate) setRotate(me.getX(), me.getY(), false);
+
             me.consume();
         });        
       }

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -738,6 +738,16 @@ public class Environment extends Application {
 	      return element;
 	 }
 	Dragable createElement(double x, double y, Dragable copied_element) {
-		return new Dragable(x, y, copied_element);
+		Dragable element = new Dragable(x, y, copied_element);
+		element.setOnMousePressed(me -> {
+		      select(element);
+		      element.setViewOrder(2);
+		      srBnd.fireEvent(me);
+		      me.consume();
+		});
+		element.setOnMouseDragged(me -> srBnd.fireEvent(me));
+		element.setOnMouseReleased(me -> srBnd.fireEvent(me));
+		element.boundsInParentProperty().addListener((v, o, n) -> updateOverlay());
+		return element;
 	}
 }

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -108,11 +108,9 @@ public class Environment extends Application {
         handleKeyboardShortcut(scene);
         scene.setOnKeyPressed(e -> {
         	pressedKeys.add(e.getCode());
-        	System.out.println("SHIFT pressed and detected");
         });
         scene.setOnKeyReleased(e -> {
-        	pressedKeys.remove(e.getCode());
-        	System.out.println("SHIFT released");        	
+        	pressedKeys.remove(e.getCode());        	
         });
         
         Rectangle floorRect = createFloor(scene); //floor
@@ -254,7 +252,7 @@ public class Environment extends Application {
         // Copy shape
         KeyCombination copyShapeKeyCombo = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
         Runnable copyShapeRunnable = () -> {
-        	boolean DEBUG = false;
+        	boolean DEBUG = true;
         	if (DEBUG) System.out.println("Accelerator Ctrl + C pressed");
         	
         	if (this.selectedElement != null) {
@@ -274,8 +272,12 @@ public class Environment extends Application {
         	boolean DEBUG = true;
         	if (DEBUG) System.out.println("Accelerator Ctrl + V pressed");
         	// first, create a deep copy of the copied shape using the reference to the old shape
+        	Dragable pastingShape = createElement(mousePosXTraker, mousePosYTraker, copiedShape);
         	// then add that deep copy into the environment where the mouse is
-        	// line 280 is a hint for adding shapes to environment
+        	// the function below is a hint for adding shapes to environment
+        	shapesInEnv.add(pastingShape);
+        	elementInEnvReporter.setText("Current element count in env: " + shapesInEnv.size());
+        	root.getChildren().add(pastingShape);
         };
         scene.getAccelerators().put(pasteShapeKeyCombo, pasteShapeRunnable);
 
@@ -334,6 +336,7 @@ public class Environment extends Application {
             		root.getChildren().remove(selectedElement);
             		shapesInEnv.remove(selectedElement);
             		overlay = null;
+            		selectedElement = null;
             	}
                 if (event.getCode() == KeyCode.SHIFT) {
                 	System.out.println("Press shift");
@@ -539,7 +542,6 @@ public class Environment extends Application {
             if (source == this.srBnd) relocate(this.shapeLayoutX + dx, this.shapeLayoutY + dy);
             else if (source == this.srNW) {
             	if (pressedKeys.contains(KeyCode.SHIFT)) {
-            		System.out.println("SHIFT key pressed");
             		double ratio = this.sHeight / this.sWidth;
             		setHSize(this.shapeLayoutX + dx, true); 
             		setVSize(this.shapeLayoutY + dx * ratio, true);


### PR DESCRIPTION
TL; DR Copy and Paste feature is running well for rectangles and pure, unresized circles : size, color, rotation are all carried over to the pasted shape. The pasted shape can be moved around, resized (with and without scale), rotated, etc. like a normal shape. 

Use case completed: copy and paste shapes
Actor: User
Precondition: app is running AND a shape is selected
Flow of events:

1. User presses ctrl and C to copy the selected shape
   1.1 User selects another shape to copy instead, then presses ctrl and C
2. The system records the selected shape.
3. User presses ctrl and V to paste the remembered shape to the environment where the mouse is at

Postcondition: the shape is pasted to the environment at the mouse.

Potential issues:
- There is no logic so far to check if the pasted shape will be out of bounds. You can paste rectangles into the ground. The pasted shape can snap out of illegal position back to legal space if you move it, but come on.
- Currently works for circles. But if you make a circle, resize it into an ellipse, then copy it, you are going to paste circles again. See this issue for explanation: https://github.com/anderm18/GaiNNs/issues/42  
