### PR TITLE
Prevent pasting to ground

### DIFF
--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -280,6 +280,8 @@ public class Environment extends Application {
         	}
         	else {
         		if (DEBUG) System.out.println("Detected mouse out of bounds");
+            	Image image = textToImage("Paste failed: mouse is out of bounds");
+//            	this.srRotate.setCursor(new ImageCursor(image, image.getWidth() / 2, image.getHeight() /2));
         	}
 
         };

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -265,15 +265,23 @@ public class Environment extends Application {
         // Paste shape
         KeyCombination pasteShapeKeyCombo = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
         Runnable pasteShapeRunnable = () -> {
-        	boolean DEBUG = false;
-        	if (DEBUG) System.out.println("Accelerator Ctrl + V pressed");
-        	// first, create a deep copy of the copied shape using the reference to the old shape
-        	Dragable pastingShape = createElement(mousePosXTraker, mousePosYTraker, copiedShape);
-        	// then add that deep copy into the environment where the mouse is
-        	// the function below is a hint for adding shapes to environment
-        	shapesInEnv.add(pastingShape);
-        	elementInEnvReporter.setText("Current element count in env: " + shapesInEnv.size());
-        	root.getChildren().add(pastingShape);
+        	boolean DEBUG = true;
+        	if (this.area.getMinX() <= this.mousePosXTraker && this.mousePosXTraker <= this.area.getMaxX()
+        		&& this.area.getMinY() <= this.mousePosYTraker && this.mousePosYTraker <= this.area.getMaxY()) {
+        		
+        		if (DEBUG) System.out.println("Accelerator Ctrl + V pressed");
+	        	// first, create a deep copy of the copied shape using the reference to the old shape
+	        	Dragable pastingShape = createElement(mousePosXTraker, mousePosYTraker, copiedShape);
+	        	// then add that deep copy into the environment where the mouse is
+	        	// the function below is a hint for adding shapes to environment
+	        	shapesInEnv.add(pastingShape);
+	        	elementInEnvReporter.setText("Current element count in env: " + shapesInEnv.size());
+	        	root.getChildren().add(pastingShape);
+        	}
+        	else {
+        		if (DEBUG) System.out.println("Detected mouse out of bounds");
+        	}
+
         };
         scene.getAccelerators().put(pasteShapeKeyCombo, pasteShapeRunnable);
 

--- a/src/main/java/com/example/gainns/Environment.java
+++ b/src/main/java/com/example/gainns/Environment.java
@@ -269,7 +269,7 @@ public class Environment extends Application {
         // Paste shape
         KeyCombination pasteShapeKeyCombo = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
         Runnable pasteShapeRunnable = () -> {
-        	boolean DEBUG = true;
+        	boolean DEBUG = false;
         	if (DEBUG) System.out.println("Accelerator Ctrl + V pressed");
         	
         	boolean legal_position = this.area.getMinX() <= this.mousePosXTraker && this.mousePosXTraker <= this.area.getMaxX()
@@ -292,27 +292,31 @@ public class Environment extends Application {
         		
         		double error_label_duration_millis = 3000;
         		
-        		Task<Void> sleeper = new Task<Void>() {
-        			@Override
-        			protected Void call() throws Exception {
-        				try { Thread.sleep((long)(error_label_duration_millis + 1000)); }
-        				catch (InterruptedException e) { }
-        				return null;
-        			}
-        	    };
-    			String error_msg = "Paste failed:";
+    			String error_msg = "Cannot paste here:";
         	    if (this.copiedShape == null) {
         	    	error_msg += " no shape is copied.";
+        	    	error_label_duration_millis += 500;
         	    }
         	    if (!legal_position) {
         	    	error_msg += " position out of bounds.";
+        	    	error_label_duration_millis += 500;
         	    }
+        	    final double error_label_duration_millis_final = error_label_duration_millis;
         	    
     			Label error_label = new Label(error_msg);
         		error_label.setLayoutX(this.mousePosXTraker + 20);
         		error_label.setLayoutY(this.mousePosYTraker);
         		root.getChildren().add(error_label);
 
+        		Task<Void> sleeper = new Task<Void>() {
+        			@Override
+        			protected Void call() throws Exception {
+        				try { Thread.sleep((long)(error_label_duration_millis_final + 1000)); }
+        				catch (InterruptedException e) { }
+        				return null;
+        			}
+        	    };
+        		
         	    sleeper.setOnSucceeded(event -> {
         	    	root.getChildren().remove(error_label);
         	    	if (DEBUG) assert(!root.getChildren().contains(error_label));


### PR DESCRIPTION
Pasting will be blocked in three cases: 
1. the user has not copied a shape yet, 
2. the position to paste the shape is incorrect,
3. both case 1 and case 2

A user-friendly message will show up near the mouse to inform the user the reason why the paste operation fails in all three cases above. The message will fade away shortly, and the time it lasts is variable so users have enough time to read the whole message, but not too long that it is cognitively burdensome.
